### PR TITLE
Add Vite React chat frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-DSPPY editor
+# DSPy Editor Chat Frontend
+
+This repository contains a TypeScript single-page application scaffolded with Vite and React that provides a chat interface for the DSPy editor backend.
+
+## Getting Started
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The development server starts on [http://localhost:5173](http://localhost:5173) and proxies API requests directly to the backend (configure your backend to listen on the same origin or adjust the fetch URLs in `src/App.tsx`).
+
+## Building for Production
+
+```bash
+cd frontend
+npm run build
+```
+
+The build output is emitted to `frontend/dist` and can be served with any static file server. To preview the production build locally, run `npm run preview` after building.
+
+## API Contracts
+
+- `POST /generate_response` — accepts `{ "prompt": string }` and returns either a streamed body or JSON payload containing the assistant reply. The response may include an `X-Turn-Id` header or a `turn_id` field in the JSON body.
+- `POST /save_edit` — accepts `{ "turn_id": string, "content": string }` and returns the persisted content (optionally in a JSON `{ "response": string }` shape).
+
+Errors returned from either endpoint are surfaced in the UI so the user can retry.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DSPy Editor Chat</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "dspy-editor-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.57",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react-swc": "^3.5.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "typescript": "^5.4.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useMemo, useState } from 'react';
+import ChatHistory from './components/ChatHistory';
+import MessageInput from './components/MessageInput';
+import type { ChatMessage } from './types';
+
+const createId = (prefix: string) =>
+  `${prefix}-${typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2)}`;
+
+const App = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const markMessage = useCallback(
+    (id: string, changes: Partial<ChatMessage>) => {
+      setMessages((prev) => prev.map((message) => (message.id === id ? { ...message, ...changes } : message)));
+    },
+    []
+  );
+
+  const handleSend = useCallback(
+    async (prompt: string) => {
+      const userMessage: ChatMessage = {
+        id: createId('user'),
+        role: 'user',
+        content: prompt,
+        status: 'ready'
+      };
+
+      const botMessageId = createId('bot');
+      const botMessage: ChatMessage = {
+        id: botMessageId,
+        role: 'bot',
+        content: '',
+        status: 'streaming'
+      };
+
+      setMessages((prev) => [...prev, userMessage, botMessage]);
+      setIsGenerating(true);
+      setErrorMessage(null);
+
+      try {
+        const response = await fetch('/generate_response', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ prompt })
+        });
+
+        if (!response.ok) {
+          throw new Error(`Unable to generate response (${response.status})`);
+        }
+
+        const contentType = response.headers.get('content-type');
+        let finalContent = '';
+        let turnId = response.headers.get('x-turn-id') ?? undefined;
+
+        if (contentType && contentType.includes('application/json')) {
+          const data = await response.json();
+          if (typeof data?.response === 'string') {
+            finalContent = data.response;
+          } else {
+            finalContent = JSON.stringify(data);
+          }
+          if (!turnId && data?.turn_id) {
+            turnId = String(data.turn_id);
+          }
+        } else if (response.body) {
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let aggregate = '';
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) {
+              break;
+            }
+            aggregate += decoder.decode(value, { stream: true });
+            markMessage(botMessageId, { content: aggregate, status: 'streaming' });
+          }
+          aggregate += decoder.decode();
+          finalContent = aggregate;
+        } else {
+          finalContent = await response.text();
+        }
+
+        markMessage(botMessageId, {
+          content: finalContent,
+          status: 'ready',
+          turnId,
+          error: undefined
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error.message : 'Unexpected error';
+        markMessage(botMessageId, {
+          content: '',
+          status: 'error',
+          error: err
+        });
+        setErrorMessage(err);
+      } finally {
+        setIsGenerating(false);
+      }
+    },
+    [markMessage]
+  );
+
+  const handleSaveEdit = useCallback(
+    async (messageId: string, content: string) => {
+      const targetMessage = messages.find((message) => message.id === messageId);
+      if (!targetMessage?.turnId) {
+        throw new Error('Missing turn ID for this message.');
+      }
+
+      markMessage(messageId, { status: 'saving-edit' });
+
+      try {
+        const response = await fetch('/save_edit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ turn_id: targetMessage.turnId, content })
+        });
+
+        if (!response.ok) {
+          throw new Error(`Unable to save edit (${response.status})`);
+        }
+
+        let updatedContent = content;
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+          try {
+            const data = await response.json();
+            if (typeof data?.response === 'string') {
+              updatedContent = data.response;
+            }
+          } catch (parseError) {
+            console.warn('Unable to parse JSON response from save_edit', parseError);
+          }
+        }
+
+        markMessage(messageId, {
+          content: updatedContent,
+          status: 'ready',
+          error: undefined
+        });
+      } catch (error) {
+        const err = error instanceof Error ? error.message : 'Unexpected error while saving edit.';
+        markMessage(messageId, { status: 'ready', error: err });
+        throw error;
+      }
+    },
+    [markMessage, messages]
+  );
+
+  const sortedMessages = useMemo(() => [...messages], [messages]);
+
+  return (
+    <div className="app-shell">
+      <ChatHistory messages={sortedMessages} onSaveEdit={handleSaveEdit} isBusy={isGenerating} />
+      <MessageInput
+        disabled={isGenerating}
+        onSend={handleSend}
+        error={errorMessage}
+        onClearError={() => setErrorMessage(null)}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/ChatHistory.tsx
+++ b/frontend/src/components/ChatHistory.tsx
@@ -1,0 +1,124 @@
+import { Fragment, type FC, useState } from 'react';
+import LoadingIndicator from './LoadingIndicator';
+import type { ChatMessage } from '../types';
+
+interface ChatHistoryProps {
+  messages: ChatMessage[];
+  onSaveEdit: (messageId: string, content: string) => Promise<void>;
+  isBusy?: boolean;
+}
+
+const ChatHistory: FC<ChatHistoryProps> = ({ messages, onSaveEdit, isBusy }) => {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState('');
+  const [savedIndicator, setSavedIndicator] = useState<Record<string, boolean>>({});
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const startEditing = (message: ChatMessage) => {
+    setEditingId(message.id);
+    setDraft(message.content);
+    setLocalError(null);
+    setSavedIndicator((prev) => ({ ...prev, [message.id]: false }));
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setDraft('');
+    setLocalError(null);
+  };
+
+  const handleSave = async (message: ChatMessage) => {
+    if (!draft.trim()) {
+      setLocalError('Response cannot be empty.');
+      return;
+    }
+
+    try {
+      setLocalError(null);
+      await onSaveEdit(message.id, draft.trim());
+      setEditingId(null);
+      setDraft('');
+      setSavedIndicator((prev) => ({ ...prev, [message.id]: true }));
+    } catch (error) {
+      const err = error instanceof Error ? error.message : 'Unable to save edit.';
+      setLocalError(err);
+    }
+  };
+
+  return (
+    <div className="panel chat-history" role="log" aria-live="polite">
+      {messages.length === 0 ? (
+        <div className="message bot" style={{ alignSelf: 'center', textAlign: 'center' }}>
+          Start the conversation by sending a prompt.
+        </div>
+      ) : null}
+      {messages.map((message) => {
+        const isEditing = editingId === message.id;
+        const showSavedIndicator = savedIndicator[message.id];
+        return (
+          <Fragment key={message.id}>
+            <article className={`message ${message.role}`}>
+              <div className="message-header">
+                <strong>{message.role === 'user' ? 'You' : 'DSPy Bot'}</strong>
+                <div className="message-actions">
+                  {message.role === 'bot' && message.turnId ? (
+                    isEditing ? (
+                      <>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={cancelEditing}
+                          disabled={message.status === 'saving-edit'}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          className="primary"
+                          onClick={() => handleSave(message)}
+                          disabled={message.status === 'saving-edit'}
+                        >
+                          Save
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={() => startEditing(message)}
+                          disabled={isBusy}
+                        >
+                          Edit
+                        </button>
+                        {showSavedIndicator ? (
+                          <button type="button" className="success" disabled>
+                            ✅ Saved
+                          </button>
+                        ) : null}
+                      </>
+                    )
+                  ) : null}
+                </div>
+              </div>
+              {isEditing ? (
+                <textarea
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  aria-label="Edit response"
+                />
+              ) : (
+                <p>{message.content}</p>
+              )}
+              {message.status === 'streaming' ? <LoadingIndicator label="Generating response…" /> : null}
+              {message.error ? <div className="error-banner">{message.error}</div> : null}
+              {isEditing && localError ? <div className="error-banner">{localError}</div> : null}
+            </article>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+export default ChatHistory;

--- a/frontend/src/components/LoadingIndicator.tsx
+++ b/frontend/src/components/LoadingIndicator.tsx
@@ -1,0 +1,16 @@
+import type { FC } from 'react';
+
+interface LoadingIndicatorProps {
+  label?: string;
+}
+
+const LoadingIndicator: FC<LoadingIndicatorProps> = ({ label = 'Waiting for the model…' }) => {
+  return (
+    <div className="loading-indicator">
+      <span className="loading-spinner" aria-hidden="true" />
+      <span>{label}</span>
+    </div>
+  );
+};
+
+export default LoadingIndicator;

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,0 +1,52 @@
+import type { FC, FormEvent } from 'react';
+import { useState } from 'react';
+
+interface MessageInputProps {
+  disabled?: boolean;
+  onSend: (content: string) => Promise<void> | void;
+  error?: string | null;
+  onClearError: () => void;
+}
+
+const MessageInput: FC<MessageInputProps> = ({ disabled, onSend, error, onClearError }) => {
+  const [prompt, setPrompt] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!prompt.trim() || isSubmitting) {
+      return;
+    }
+
+    onClearError();
+    setIsSubmitting(true);
+    try {
+      await onSend(prompt.trim());
+      setPrompt('');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="panel input-panel" onSubmit={handleSubmit}>
+      {error ? <div className="error-banner" role="status">{error}</div> : null}
+      <textarea
+        className="prompt-input"
+        placeholder="Ask the model anything…"
+        value={prompt}
+        onChange={(event) => setPrompt(event.target.value)}
+        disabled={disabled || isSubmitting}
+        aria-label="Prompt"
+      />
+      <div className="submit-row">
+        <span>{isSubmitting ? 'Sending…' : 'Shift + Enter for new line'}</span>
+        <button type="submit" disabled={disabled || isSubmitting}>
+          Send
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default MessageInput;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,214 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  background: linear-gradient(160deg, #0f172a 0%, #1e293b 100%);
+}
+
+#root {
+  flex: 1;
+  display: flex;
+}
+
+.app-shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  gap: 1.5rem;
+}
+
+.panel {
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(12px);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+  overflow: hidden;
+}
+
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  max-width: 720px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: linear-gradient(120deg, #0ea5e9, #2563eb);
+  color: white;
+}
+
+.message.bot {
+  align-self: flex-start;
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.message-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.875rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.message-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.message textarea {
+  width: 100%;
+  min-height: 6rem;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.8);
+  color: inherit;
+  resize: vertical;
+}
+
+.message button {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.8rem;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.message button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  opacity: 0.85;
+}
+
+.message button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.message button.secondary {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  color: inherit;
+}
+
+.message button.primary {
+  background: linear-gradient(120deg, #10b981, #22c55e);
+  color: #0f172a;
+}
+
+.message button.success {
+  background: rgba(34, 197, 94, 0.15);
+  border: 1px solid rgba(34, 197, 94, 0.5);
+  color: rgba(134, 239, 172, 1);
+}
+
+.loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.loading-spinner {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 3px solid rgba(226, 232, 240, 0.15);
+  border-top-color: rgba(56, 189, 248, 0.95);
+  animation: spin 0.9s linear infinite;
+}
+
+.input-panel {
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.prompt-input {
+  width: 100%;
+  min-height: 6rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  padding: 1rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.submit-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.submit-row button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.submit-row button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.submit-row button:not(:disabled):hover {
+  transform: translateY(-1px);
+  opacity: 0.85;
+}
+
+.error-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: rgba(252, 165, 165, 1);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,10 @@
+export type Role = 'user' | 'bot';
+
+export interface ChatMessage {
+  id: string;
+  role: Role;
+  content: string;
+  turnId?: string;
+  status?: 'streaming' | 'ready' | 'saving-edit' | 'error';
+  error?: string;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react-swc';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript single-page app for the DSPy editor frontend
- implement chat history, input, and loading components with editing workflow for bot replies
- connect UI to backend endpoints for generating responses and saving edits with streaming support and error handling

## Testing
- `npm install` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68d01ebd6be4832a98ebddf603194bd1